### PR TITLE
Improve reliability of basic usage and address several minor issues

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -22,4 +22,4 @@ jobs:
         run: deno lint --unstable
 
       - name: Run tests
-        run: deno test --unstable --allow-read --allow-env --allow-run
+        run: deno test --unstable --shuffle --allow-read --allow-env --allow-run --allow-write

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,10 +1,10 @@
-name: Lint
+name: Lint and Test
 
 on: [push, pull_request]
 
 jobs:
-  lint:
-    name: Lint source
+  lint-and-test:
+    name: Lint and test source
     runs-on: ubuntu-latest
     steps:
       - name: Setup repo
@@ -20,3 +20,6 @@ jobs:
 
       - name: Run linter
         run: deno lint --unstable
+
+      - name: Run tests
+        run: deno test --unstable

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -22,4 +22,4 @@ jobs:
         run: deno lint --unstable
 
       - name: Run tests
-        run: deno test --unstable
+        run: deno test --unstable --allow-read --allow-env --allow-run

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .vscode
+.tmp/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     <img alt="issues" src="https://img.shields.io/github/issues/c4spar/deno-dzx?label=issues&logo=github">
   </a>
   <a href="https://deno.land/">
-    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.10.0-blue?logo=deno&color=blue" />
+    <img alt="Deno version" src="https://img.shields.io/badge/deno-^1.13.0-blue?logo=deno&color=blue" />
   </a>
   <a href="https://github.com/c4spar/deno-dzx/blob/main/LICENSE">
     <img alt="Licence" src="https://img.shields.io/github/license/c4spar/deno-dzx?logo=github" />

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ console.log(`Hello from ${$.blue.bold("worker")}!`);
 ## Variables
 
 - **$.shell:** Set the shell that is used by `` $`command` ``. Default:
-  `/bin/sh`
+  `/bin/bash`
 - **$.prefix:** Command prefix. Default: `set -euo pipefail;`.
 - **$.mainModule:** The executed dzx script.
 - **$.verbose:** Enable debugging output (log shell commands and execution

--- a/src/cli/bundle.ts
+++ b/src/cli/bundle.ts
@@ -1,4 +1,4 @@
-import { Command, ValidationError } from "./deps.ts";
+import { Command, copy, ValidationError } from "./deps.ts";
 import { error } from "../_utils.ts";
 import { path } from "../../mod.ts";
 
@@ -14,7 +14,7 @@ export function bundleCommand() {
         }
         script = await Deno.makeTempFile({ suffix: ".ts" });
         const tmpFile = await Deno.open(script, { write: true });
-        await Deno.copy(Deno.stdin, tmpFile);
+        await copy(Deno.stdin, tmpFile);
         tmpFile.close();
       }
       console.log(

--- a/src/cli/bundle.ts
+++ b/src/cli/bundle.ts
@@ -68,8 +68,18 @@ async function bundleFile(
     const result = await Deno.emit(file, {
       bundle: "module",
       check: true,
+      compilerOptions: {
+        sourceMap: false, // Set sourcemaps to be false so that the resultant files array only has one entry
+      },
       ...options,
     });
+
+    // TODO - the key order of `result.files` is non-deterministic, so this might
+    // need to be reworked a bit to more selectively pull out the bundled file
+    // result that is desired. In the short term, it is reasonably well known
+    // that the first file will be *the only file* when sourcemaps are turned
+    // off in the compiler options (note that not doing this results in
+    // intermittently failing results on repeated calls to `dzx bundle`)
     return Object.values(result.files)[0] as string;
   } catch (err) {
     if (err instanceof Deno.errors.NotFound) {

--- a/src/cli/compile.ts
+++ b/src/cli/compile.ts
@@ -1,6 +1,6 @@
 import { preBundle } from "./bundle.ts";
 import { error } from "../_utils.ts";
-import { Command, ValidationError } from "./deps.ts";
+import { Command, copy, ValidationError } from "./deps.ts";
 
 export function compileCommand() {
   return new Command<void>()
@@ -39,7 +39,7 @@ export function compileCommand() {
           }
           script = await Deno.makeTempFile();
           const tmpFile = await Deno.open(script);
-          await Deno.copy(Deno.stdin, tmpFile);
+          await copy(Deno.stdin, tmpFile);
         }
         if (["-h", "--help"].includes(script)) {
           this.showHelp();

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -1,5 +1,5 @@
-export { Command } from "https://deno.land/x/cliffy@v0.18.2/command/command.ts";
+export { Command } from "https://deno.land/x/cliffy@v0.19.5/command/command.ts";
 export {
   ValidationError,
-} from "https://deno.land/x/cliffy@v0.18.2/flags/_errors.ts";
+} from "https://deno.land/x/cliffy@v0.19.5/flags/_errors.ts";
 export { copy } from "https://deno.land/std@0.104.0/io/mod.ts";

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -2,3 +2,4 @@ export { Command } from "https://deno.land/x/cliffy@v0.18.2/command/command.ts";
 export {
   ValidationError,
 } from "https://deno.land/x/cliffy@v0.18.2/flags/_errors.ts";
+export { copy } from "https://deno.land/std@0.104.0/io/mod.ts";

--- a/src/runtime/deps.ts
+++ b/src/runtime/deps.ts
@@ -1,24 +1,24 @@
-export * as async from "https://deno.land/std@0.93.0/async/mod.ts";
-export type { Deferred } from "https://deno.land/std@0.93.0/async/mod.ts";
-export * as path from "https://deno.land/std@0.93.0/path/mod.ts";
+export * as async from "https://deno.land/std@0.104.0/async/mod.ts";
+export type { Deferred } from "https://deno.land/std@0.104.0/async/mod.ts";
+export * as path from "https://deno.land/std@0.104.0/path/mod.ts";
 export type {
   FormatInputPathObject,
   GlobOptions,
   GlobToRegExpOptions,
   ParsedPath,
-} from "https://deno.land/std@0.93.0/path/mod.ts";
-export * as io from "https://deno.land/std@0.93.0/io/mod.ts";
-export type { ReadLineResult } from "https://deno.land/std@0.93.0/io/mod.ts";
-export * as fs from "https://deno.land/std@0.93.0/fs/mod.ts";
-export * as log from "https://deno.land/std@0.93.0/log/mod.ts";
+} from "https://deno.land/std@0.104.0/path/mod.ts";
+export * as io from "https://deno.land/std@0.104.0/io/mod.ts";
+export type { ReadLineResult } from "https://deno.land/std@0.104.0/io/mod.ts";
+export * as fs from "https://deno.land/std@0.104.0/fs/mod.ts";
+export * as log from "https://deno.land/std@0.104.0/log/mod.ts";
 export type {
   LevelName,
   LogConfig,
-} from "https://deno.land/std@0.93.0/log/mod.ts";
-export * as flags from "https://deno.land/std@0.93.0/flags/mod.ts";
+} from "https://deno.land/std@0.104.0/log/mod.ts";
+export * as flags from "https://deno.land/std@0.104.0/flags/mod.ts";
 export type {
   ArgParsingOptions,
   Args,
-} from "https://deno.land/std@0.93.0/flags/mod.ts";
+} from "https://deno.land/std@0.104.0/flags/mod.ts";
 export { colors } from "https://deno.land/x/cliffy@v0.18.2/ansi/colors.ts";
 export { default as shq } from "https://esm.sh/shq@1.0.2";

--- a/src/runtime/deps.ts
+++ b/src/runtime/deps.ts
@@ -20,5 +20,5 @@ export type {
   ArgParsingOptions,
   Args,
 } from "https://deno.land/std@0.104.0/flags/mod.ts";
-export { colors } from "https://deno.land/x/cliffy@v0.18.2/ansi/colors.ts";
+export { colors } from "https://deno.land/x/cliffy@v0.19.5/ansi/colors.ts";
 export { default as shq } from "https://esm.sh/shq@1.0.2";

--- a/src/runtime/exec.ts
+++ b/src/runtime/exec.ts
@@ -31,6 +31,10 @@ export async function exec(
     process.stderr && read(process.stderr, stderr, combined),
   ]);
 
+  process.stdout?.close();
+  process.stderr?.close();
+  process.close();
+
   if (--runningProcesses === 0) {
     $.stdout = "piped";
   }

--- a/src/runtime/exec.ts
+++ b/src/runtime/exec.ts
@@ -6,10 +6,15 @@ let runningProcesses = 0;
 
 export async function exec(
   pieces: TemplateStringsArray,
-  ...args: Array<string | number>
+  ...args: Array<string | number | ProcessOutput>
 ): Promise<ProcessOutput> {
   runningProcesses++;
-  const cmd = quote(pieces, ...args);
+  const cmd = quote(
+    pieces,
+    ...args.map((
+      a,
+    ) => (a instanceof ProcessOutput ? a.stdout.replace(/\n$/, "") : a)),
+  );
 
   if ($.verbose) {
     console.log($.brightBlue("$ %s"), cmd);

--- a/src/runtime/mod.ts
+++ b/src/runtime/mod.ts
@@ -3,7 +3,7 @@ import { cd } from "./cd.ts";
 import { exec } from "./exec.ts";
 import { quote } from "./quote.ts";
 
-export type $ = typeof exec & typeof colors & {
+export type $Global = typeof exec & typeof colors & {
   shell: string;
   prefix: string;
   mainModule: string;
@@ -17,7 +17,7 @@ export type $ = typeof exec & typeof colors & {
   time: number;
 };
 
-export const $: $ = exec as $;
+export const $: $Global = exec as $Global;
 
 Object.setPrototypeOf($, Object.getPrototypeOf(colors));
 

--- a/src/runtime/mod.ts
+++ b/src/runtime/mod.ts
@@ -23,7 +23,7 @@ Object.setPrototypeOf($, Object.getPrototypeOf(colors));
 
 $._stack = [];
 $.shell = "/bin/sh";
-$.prefix = "set -euo pipefail;";
+$.prefix = "set -eu;";
 $.mainModule = "";
 $.verbose = false;
 $.stdout = "piped";

--- a/src/runtime/mod.ts
+++ b/src/runtime/mod.ts
@@ -3,6 +3,9 @@ import { cd } from "./cd.ts";
 import { exec } from "./exec.ts";
 import { quote } from "./quote.ts";
 
+export { ProcessError } from "./process_error.ts";
+export { ProcessOutput } from "./process_output.ts";
+
 export type $Global = typeof exec & typeof colors & {
   shell: string;
   prefix: string;

--- a/src/runtime/mod.ts
+++ b/src/runtime/mod.ts
@@ -6,7 +6,7 @@ import { quote } from "./quote.ts";
 export { ProcessError } from "./process_error.ts";
 export { ProcessOutput } from "./process_output.ts";
 
-export type $Global = typeof exec & typeof colors & {
+export type $ = typeof exec & typeof colors & {
   shell: string;
   prefix: string;
   mainModule: string;
@@ -20,13 +20,13 @@ export type $Global = typeof exec & typeof colors & {
   time: number;
 };
 
-export const $: $Global = exec as $Global;
+export const $: $ = exec as $;
 
 Object.setPrototypeOf($, Object.getPrototypeOf(colors));
 
 $._stack = [];
-$.shell = "/bin/sh";
-$.prefix = "set -eu;";
+$.shell = "/bin/bash";
+$.prefix = "set -euo pipefail;";
 $.mainModule = "";
 $.verbose = false;
 $.stdout = "piped";

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,11 @@
+/// <reference path="./types.d.ts" />
+
+import { assertEquals } from "https://deno.land/std@0.104.0/testing/asserts.ts";
+
+import { $ } from "./mod.ts";
+
+Deno.test("$ works", async () => {
+  const result = await $`echo hello`;
+
+  assertEquals(result.stdout, "hello\n");
+});

--- a/test.ts
+++ b/test.ts
@@ -1,11 +1,64 @@
 /// <reference path="./types.d.ts" />
 
-import { assertEquals } from "https://deno.land/std@0.104.0/testing/asserts.ts";
+import {
+  assert,
+  assertEquals,
+  assertThrowsAsync,
+} from "https://deno.land/std@0.104.0/testing/asserts.ts";
 
-import { $ } from "./mod.ts";
+import { $, cd, path, ProcessError } from "./mod.ts";
 
 Deno.test("$ works", async () => {
   const result = await $`echo hello`;
 
   assertEquals(result.stdout, "hello\n");
+});
+
+Deno.test("passing environment variables to the child process", async () => {
+  Deno.env.set("IS_THIS_THING_ON", "yes");
+  const result = await $`echo $IS_THIS_THING_ON`;
+
+  assertEquals(result.stdout, "yes\n");
+});
+
+Deno.test("escape and quote arguments", async () => {
+  const complexArg = 'bar"";baz!$#^$\'&*~*%)({}||\\/';
+  const result = (await $`echo ${complexArg}`);
+
+  assertEquals(result.stdout.trim(), complexArg);
+});
+
+Deno.test("create a directory with a space in the name", async () => {
+  const now = Date.now();
+  const path = `./.tmp/test_${now}/foo bar`;
+
+  try {
+    await $`mkdir -p ${path}`;
+    assert((await Deno.stat(path)).isDirectory);
+  } finally {
+    await Deno.remove(`./.tmp`, { recursive: true });
+  }
+});
+
+Deno.test("subprocess command failure throws a ProcessError", async () => {
+  await assertThrowsAsync(async () => await $`somefakebinary`, ProcessError);
+});
+
+Deno.test("cwd of the parent process is always the starting point for calls to cd", async () => {
+  const parentPwd = Deno.cwd();
+
+  try {
+    const testStartingDir = path.dirname(path.fromFileUrl(import.meta.url));
+    Deno.chdir(testStartingDir);
+
+    cd("src");
+    const pwd1 = await $`pwd`;
+    assertEquals(pwd1.stdout.trim(), path.join(testStartingDir, "src"));
+
+    cd(".github");
+    const pwd2 = await $`pwd`;
+    assertEquals(pwd2.stdout.trim(), path.join(testStartingDir, ".github"));
+  } finally {
+    Deno.chdir(parentPwd);
+  }
 });

--- a/test.ts
+++ b/test.ts
@@ -14,6 +14,14 @@ Deno.test("$ works", async () => {
   assertEquals(result.stdout, "hello\n");
 });
 
+Deno.test("only stdout of an exec result will be used if passed to a second call to exec", async () => {
+  const result1 = await $`echo sup >&2; echo hiii`;
+  assertEquals(result1.stderr, "sup\n");
+
+  const result2 = await $`echo ${result1}`;
+  assertEquals(result2.stdout, "hiii\n");
+});
+
 Deno.test("passing environment variables to the child process", async () => {
   Deno.env.set("IS_THIS_THING_ON", "yes");
   const result = await $`echo $IS_THIS_THING_ON`;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 import type {
-  $,
+  $Global,
   async as _async,
   cd as _cd,
   flags as _flags,
@@ -25,7 +25,7 @@ import type {
 
 declare global {
   // dzx
-  const $: $;
+  const $: $Global;
   const cd: typeof _cd;
   const quote: typeof _quote;
 
@@ -64,7 +64,7 @@ declare global {
 
   interface Window {
     // dzx
-    $: $;
+    $: $Global;
     cd: typeof _cd;
     quote: typeof _quote;
 
@@ -79,7 +79,7 @@ declare global {
 
   interface WorkerGlobalScope {
     // dzx
-    $: $;
+    $: $Global;
     cd: typeof _cd;
     quote: typeof _quote;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 import type {
-  $Global,
+  $,
   async as _async,
   cd as _cd,
   flags as _flags,
@@ -25,7 +25,7 @@ import type {
 
 declare global {
   // dzx
-  const $: $Global;
+  const $: $;
   const cd: typeof _cd;
   const quote: typeof _quote;
 
@@ -64,7 +64,7 @@ declare global {
 
   interface Window {
     // dzx
-    $: $Global;
+    $: $;
     cd: typeof _cd;
     quote: typeof _quote;
 
@@ -79,7 +79,7 @@ declare global {
 
   interface WorkerGlobalScope {
     // dzx
-    $: $Global;
+    $: $;
     cd: typeof _cd;
     quote: typeof _quote;
 


### PR DESCRIPTION
Thanks a lot for producing such awesome libraries for the Deno community! I have used `cliffy` on another project and wanted to give back :D

I really love the ergonomics of `zx` and use it heavily for my own scripting needs, but I think that `Deno` is actually even better suited to the use case since it can reference third party code with a much more straightforward mechanism via urls. Your `dzx` library is amazing, and really well organized but when I went to use it I ran into a few issues that were simple enough for me to just take a look and address. Hopefully these can save you some keystrokes!

Note that I tried to use very discrete and linear commits which fully encapsulate the steps I took to address things. If you have any questions, please feel free to let me know!

Included updates and fixes:

(https://github.com/c4spar/deno-dzx/commit/adbbf73802546ea91a496652a008dbbaea20a7d8) **Lint fixes**
> Deno lint was failing due to the deprecation of Deno.copy as well as a re-declared global identifier
for $. Both of these issues are now fixed, however as a side effect, the version of the std library
needed to be updated to have access to the ioutil.copy method, and since the std lib was updated to
the latest, the supported semver version of deno in the readme also needed to be udpate.

(https://github.com/c4spar/deno-dzx/commit/f89e1dc8ba56c6212c4469c78bd518b68e5f9f46) and then (https://github.com/c4spar/deno-dzx/commit/129c46420f3699e911e581c4ef64b588954d5a29) **Testing basics**
> Add a testing step to ci, then add a baseline test so that `deno test` does not fail to find a test file in ci, but note that at the point of these commits this test failed for more a few reasons which will be fixed in a subsequent commit

(https://github.com/c4spar/deno-dzx/commit/b1f88d62952557e9c0cd3a1ccc3ccef2dcdfcf22) **Passing initial test**
> There were two reasons the tests were failing initially; (1) the dash shell (`/bin/sh`) does not
have the "pipefail" option, and (2) the child process was leaking file descriptors. These are both
resolved now by (1) removing the pipefail option and (2) ensuring that if the out/err pipes are
present on the child process that they are closed and that the process as a whole is also closed.

(https://github.com/c4spar/deno-dzx/commit/175ae578335e6334bf286fa3299cad7efafebbb1) **Core functionality tests**

(https://github.com/c4spar/deno-dzx/commit/6df1f851a6e4faa4e9408f44cef940a33b962821) **Bump deps now that tests exist**

(https://github.com/c4spar/deno-dzx/commit/1f40248928c446f7e935bd783994de7860eb314f) and then (https://github.com/c4spar/deno-dzx/commit/686639218289eb439a0af59195e6e98c2c98d1fd) **New Feature**: Allow passing one `exec` result into another for improved ergonomics between steps in a script. Then add tests against this.


Two more things:
- I found with `dzx bundle` that due to the lack of explicit compiler options opting out of sourcemaps, that `Deno.emit` would emit sourcemaps in the `result.files` array, and sometimes the sourcemap would be the first entry, and other times it wouldn't. Whenever the sourcemap was first in the array, the `dzx bundle` command would fail. To fix this intermittent failure, I added explicit opt-out of soucemaps, which improves the reliability of just grabbing the first element of the results array. It's not perfect though, so I left a `TODO` comment to look at it more closely.
- I wonder if the default `$.shell` option should just be `bash` and not `sh`? This would enable putting the `pipefail` option back in the `prefix` and I think it might be nice to optimize for a default use case of people who have `bash` vs the less common scenario where someone is running without `bash` available - since such users can just override back to `/bin/sh` this seems safe enough IMO. I'll also note that in my testing, you don't actually need to supply the fully qualified executable path, so just `$.shell = 'bash'` will work (saving having to look up where bash is installed). Perhaps at a later time it might be nice to do a quick lookup at `dzx` startup that checks for bash and if found, uses it with a more restrictive prefix, then if not found, falls back to sh automatically with the more permissive prefix. Thoughts?