### PR TITLE
feat(cli): add the ability to run markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ the `dzx` cli.
 console.log(`Hello from ${$.blue.bold("worker")}!`);
 ```
 
+## Markdown
+
+With `dzx` you can run the `js`/`ts` code blocks from a Markdown file as if they were a regular script. This is very convenient when you want to blend some nicely formatted documentation in with the actual steps of execution.
+
+Give it a try by running:
+
+```bash
+dzx ./examples/markdown.md
+```
+
+See the [markdown example](./examples/markdown.md) for further documentation and notes.
+
 ## Methods
 
 - `` $`command` ``: Executes a shell command.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ console.log(`Hello from ${$.blue.bold("worker")}!`);
 
 ## Markdown
 
-With `dzx` you can run the `js`/`ts` code blocks from a Markdown file as if they were a regular script. This is very convenient when you want to blend some nicely formatted documentation in with the actual steps of execution.
+With `dzx` you can run the `js`/`ts` code blocks from a Markdown file as if they
+were a regular script. This is very convenient when you want to blend some
+nicely formatted documentation in with the actual steps of execution.
 
 Give it a try by running:
 
@@ -154,7 +156,8 @@ Give it a try by running:
 dzx ./examples/markdown.md
 ```
 
-See the [markdown example](./examples/markdown.md) for further documentation and notes.
+See the [markdown example](./examples/markdown.md) for further documentation and
+notes.
 
 ## Methods
 

--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -1,0 +1,88 @@
+# Documentation + Code Block Execution = ❤️🦕
+
+`dzx` permits the execution of "fenced" code blocks in Markdown files. Simply mark your triple-back-tick code fence with one of the following supported languages codes:
+
+- `js`
+- `javascript`
+- `ts`
+- `typescript`
+
+and your code blocks will all be collected into a single file and executed just like any other script by `dzx`.
+
+## The First Block to Execute
+
+```ts
+$.verbose = true;
+
+const name = 'World';
+await $`echo "Hello ${name}!"`;
+```
+
+## Some Details
+
+- Only triple-back-tick "fenced" code blocks are executed, i.e. `inline code` is ignored.
+- Only code blocks marked with a supported language code will be executed, i.e. the following code block:
+
+  ```ruby
+  name = 'world'
+  puts "Hello #{name}!"
+  ```
+
+  will be ignored since `ruby` is not supported. This restriction also applies to code blocks _with no language code at all_.
+
+- _Every_ supported code block will be executed, as one single script, in the order they are written. The code blocks will simply be extracted from the markdown, then concatenated together and saved to a temporary file for execution. This means that a given code block **is not** isolated from the others when executed!
+
+## A Second Block to Execute
+
+```ts
+// Note that we're using the `name`
+// defined in the first code block
+await $`echo "Hello again ${name}!"`;
+```
+
+## Technical Gotchas
+
+- The code blocks will be extracted, concatenated together, and saved to a temporary file created by `Deno.makeTempFile`. It is _this temp file_ that is actually executed by `Deno`, which means that the value of `import.meta.url` _would_ point to a file in your system `tmp` directory at runtime.
+
+  To permit usage of `import.meta.url` within your code blocks, `dzx` replaces all occurrences of `import.meta.url` within every code block with the literal string value of the original markdown file as a file url (essentially what you would get if `Deno` could natively run the markdown file and you used the import meta). This replacement happens naively, without any attempt to determine if the import meta was being used in a template string, was being concatenated to to another string, or anything else - just a straight up `String.prototype.replaceAll`.
+
+  ```js
+  // TLDR: keep your usage of `import.meta.url` simple and naive-string-replacement friendly ❤️
+  const importMetaUrl = import.meta.url;
+  // this line will be replace at compile-time with (for example):
+  // const importMetaUrl = "file:///home/user/code/example.md";
+  console.log({ importMetaUrl });
+  ```
+
+- If you installed `dzx` without the `--no-check` flag, then your code blocks will be type checked. If you don't want that, you can either re-install `dzx` with the `--no-check` flag included, or add `// @ts-nocheck <reason>` as a fenced code block of its own at the top of your markdown file (or just before the first line of code in whatever your first fenced code block is).
+
+- You do not need to add a `shebang` (e.g. `#!/usr/bin/env dzx`) to your code blocks, nor do you need to add a reference to the `dzx` types. Both of these will be automatically inserted at the top of the compiled (temp file) typescript module.
+
+## Wrapping up
+
+If you run *this Markdown file* with `dzx`, the compiled script file will be something like this:
+
+```
+#!/usr/bin/env dzx
+/// <reference path="https://deno.land/x/dzx@0.2.4/types.d.ts" />
+// deno-lint-ignore-file
+
+$.verbose = true;
+
+const name = 'World';
+await $`echo "Hello ${name}!"`;
+// Note that we're using the `name`
+// defined in the first code block
+await $`echo "Hello again ${name}!"`;
+// TLDR: keep your usage of `"file:///<redacted>/dzx/examples/markdown.md"` simple and naive-string-replacement friendly ❤️
+const importMetaUrl = "file:///<redacted>/dzx/examples/markdown.md";
+// this line will be replace at compile-time with (for example):
+// const importMetaUrl = "file:///home/user/code/example.md";
+console.log({ importMetaUrl });
+```
+
+Note that when executed, the path to the compiled script temp file will be printed to the console, so you can always review what `Deno` executed if something goes wrong. The message will look like:
+
+```
+Markdown module saved to /tmp/dzx_e2d2e74f_module.ts
+```

--- a/examples/markdown.md
+++ b/examples/markdown.md
@@ -1,36 +1,46 @@
 # Documentation + Code Block Execution = ❤️🦕
 
-`dzx` permits the execution of "fenced" code blocks in Markdown files. Simply mark your triple-back-tick code fence with one of the following supported languages codes:
+`dzx` permits the execution of "fenced" code blocks in Markdown files. Simply
+mark your triple-back-tick code fence with one of the following supported
+languages codes:
 
 - `js`
 - `javascript`
 - `ts`
 - `typescript`
 
-and your code blocks will all be collected into a single file and executed just like any other script by `dzx`.
+and your code blocks will all be collected into a single file and executed just
+like any other script by `dzx`.
 
 ## The First Block to Execute
 
 ```ts
 $.verbose = true;
 
-const name = 'World';
+const name = "World";
 await $`echo "Hello ${name}!"`;
 ```
 
 ## Some Details
 
-- Only triple-back-tick "fenced" code blocks are executed, i.e. `inline code` is ignored.
-- Only code blocks marked with a supported language code will be executed, i.e. the following code block:
+- Only triple-back-tick "fenced" code blocks are executed, i.e. `inline code` is
+  ignored.
+- Only code blocks marked with a supported language code will be executed, i.e.
+  the following code block:
 
   ```ruby
   name = 'world'
   puts "Hello #{name}!"
   ```
 
-  will be ignored since `ruby` is not supported. This restriction also applies to code blocks _with no language code at all_.
+  will be ignored since `ruby` is not supported. This restriction also applies
+  to code blocks _with no language code at all_.
 
-- _Every_ supported code block will be executed, as one single script, in the order they are written. The code blocks will simply be extracted from the markdown, then concatenated together and saved to a temporary file for execution. This means that a given code block **is not** isolated from the others when executed!
+- _Every_ supported code block will be executed, as one single script, in the
+  order they are written. The code blocks will simply be extracted from the
+  markdown, then concatenated together and saved to a temporary file for
+  execution. This means that a given code block **is not** isolated from the
+  others when executed!
 
 ## A Second Block to Execute
 
@@ -42,9 +52,19 @@ await $`echo "Hello again ${name}!"`;
 
 ## Technical Gotchas
 
-- The code blocks will be extracted, concatenated together, and saved to a temporary file created by `Deno.makeTempFile`. It is _this temp file_ that is actually executed by `Deno`, which means that the value of `import.meta.url` _would_ point to a file in your system `tmp` directory at runtime.
+- The code blocks will be extracted, concatenated together, and saved to a
+  temporary file created by `Deno.makeTempFile`. It is _this temp file_ that is
+  actually executed by `Deno`, which means that the value of `import.meta.url`
+  _would_ point to a file in your system `tmp` directory at runtime.
 
-  To permit usage of `import.meta.url` within your code blocks, `dzx` replaces all occurrences of `import.meta.url` within every code block with the literal string value of the original markdown file as a file url (essentially what you would get if `Deno` could natively run the markdown file and you used the import meta). This replacement happens naively, without any attempt to determine if the import meta was being used in a template string, was being concatenated to to another string, or anything else - just a straight up `String.prototype.replaceAll`.
+  To permit usage of `import.meta.url` within your code blocks, `dzx` replaces
+  all occurrences of `import.meta.url` within every code block with the literal
+  string value of the original markdown file as a file url (essentially what you
+  would get if `Deno` could natively run the markdown file and you used the
+  import meta). This replacement happens naively, without any attempt to
+  determine if the import meta was being used in a template string, was being
+  concatenated to to another string, or anything else - just a straight up
+  `String.prototype.replaceAll`.
 
   ```js
   // TLDR: keep your usage of `import.meta.url` simple and naive-string-replacement friendly ❤️
@@ -54,13 +74,21 @@ await $`echo "Hello again ${name}!"`;
   console.log({ importMetaUrl });
   ```
 
-- If you installed `dzx` without the `--no-check` flag, then your code blocks will be type checked. If you don't want that, you can either re-install `dzx` with the `--no-check` flag included, or add `// @ts-nocheck <reason>` as a fenced code block of its own at the top of your markdown file (or just before the first line of code in whatever your first fenced code block is).
+- If you installed `dzx` without the `--no-check` flag, then your code blocks
+  will be type checked. If you don't want that, you can either re-install `dzx`
+  with the `--no-check` flag included, or add `// @ts-nocheck <reason>` as a
+  fenced code block of its own at the top of your markdown file (or just before
+  the first line of code in whatever your first fenced code block is).
 
-- You do not need to add a `shebang` (e.g. `#!/usr/bin/env dzx`) to your code blocks, nor do you need to add a reference to the `dzx` types. Both of these will be automatically inserted at the top of the compiled (temp file) typescript module.
+- You do not need to add a `shebang` (e.g. `#!/usr/bin/env dzx`) to your code
+  blocks, nor do you need to add a reference to the `dzx` types. Both of these
+  will be automatically inserted at the top of the compiled (temp file)
+  typescript module.
 
 ## Wrapping up
 
-If you run *this Markdown file* with `dzx`, the compiled script file will be something like this:
+If you run _this Markdown file_ with `dzx`, the compiled script file will be
+something like this:
 
 ```
 #!/usr/bin/env dzx
@@ -81,7 +109,9 @@ const importMetaUrl = "file:///<redacted>/dzx/examples/markdown.md";
 console.log({ importMetaUrl });
 ```
 
-Note that when executed, the path to the compiled script temp file will be printed to the console, so you can always review what `Deno` executed if something goes wrong. The message will look like:
+Note that when executed, the path to the compiled script temp file will be
+printed to the console, so you can always review what `Deno` executed if
+something goes wrong. The message will look like:
 
 ```
 Markdown module saved to /tmp/dzx_e2d2e74f_module.ts

--- a/src/cli/deps.ts
+++ b/src/cli/deps.ts
@@ -5,3 +5,4 @@ export {
   ValidationError,
 } from "https://deno.land/x/cliffy@v0.19.5/command/_errors.ts";
 export { copy } from "https://deno.land/std@0.104.0/io/mod.ts";
+export { tokens } from "https://deno.land/x/rusty_markdown@v0.4.1/mod.ts";

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -118,7 +118,7 @@ export function dzx() {
 
       await Deno.writeTextFile(mdRealPath, mdContent);
 
-      console.log($.dim(`Markdown source saved to ${mdRealPath}`));
+      console.error($.dim(`Markdown source saved to ${mdRealPath}`));
     }
 
     mdRealPath ??= await Deno.realPath(md);
@@ -157,7 +157,7 @@ export function dzx() {
       suffix: `_module.ts`,
     });
 
-    console.log($.dim(`Markdown module saved to ${tmp}\n`));
+    console.error($.dim(`Markdown module saved to ${tmp}\n`));
 
     const finalCode = codeContent.join("").replaceAll(
       "import.meta.url",

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -5,6 +5,7 @@ import { compileCommand } from "./compile.ts";
 import {
   Command,
   DenoLandProvider,
+  tokens,
   UpgradeCommand,
   ValidationError,
 } from "./deps.ts";
@@ -70,7 +71,12 @@ export function dzx() {
       ) => {
         $.args = args;
         if (script) {
-          $.mainModule = addProtocool(script);
+          const scriptExt = path.extname(script);
+
+          $.mainModule = [".md", ".markdown"].includes(scriptExt)
+            ? await moduleFromMarkdown(script)
+            : addProtocool(script);
+
           if (worker) {
             spawnWorker(perms);
           } else {
@@ -95,6 +101,81 @@ export function dzx() {
         provider: new DenoLandProvider(),
       }),
     );
+
+  async function moduleFromMarkdown(md: string) {
+    let mdRealPath;
+    let mdContent;
+
+    if (
+      md.startsWith("http://") ||
+      md.startsWith("https://")
+    ) {
+      mdContent = await fetch(md).then((r) => r.text());
+      mdRealPath = await Deno.makeTempFile({
+        prefix: "dzx_",
+        suffix: `_source.md`,
+      });
+
+      await Deno.writeTextFile(mdRealPath, mdContent);
+
+      console.log($.dim(`Markdown source saved to ${mdRealPath}`));
+    }
+
+    mdRealPath ??= await Deno.realPath(md);
+    mdContent ??= await Deno.readTextFile(mdRealPath);
+    const mdFileURL = path.toFileUrl(await Deno.realPath(mdRealPath));
+    const mdTokens = tokens(mdContent);
+
+    const validLangs = ["js", "javascript", "ts", "typescript"];
+    const codeContent: string[] = [];
+
+    mdTokens.forEach((token, idx) => {
+      if (
+        token.type === "start" && token.tag === "codeBlock" &&
+        token.kind === "fenced" &&
+        validLangs
+          .includes(token.language)
+      ) {
+        let cursor = idx + 1;
+
+        while (mdTokens.at(cursor)?.type === "text") {
+          const code = mdTokens.at(cursor);
+
+          // Silly typescript, can't narrow this down based on
+          // the while loop condition...ah well
+          if (code?.type === "text") {
+            codeContent.push(code.content);
+          }
+
+          cursor++;
+        }
+      }
+    });
+
+    const tmp = await Deno.makeTempFile({
+      prefix: "dzx_",
+      suffix: `_module.ts`,
+    });
+
+    console.log($.dim(`Markdown module saved to ${tmp}\n`));
+
+    const finalCode = codeContent.join("").replaceAll(
+      "import.meta.url",
+      `\"${mdFileURL}\"`,
+    );
+
+    await Deno.writeTextFile(
+      tmp,
+      `#!/usr/bin/env dzx
+       /// <reference path="https://deno.land/x/dzx@${VERSION}/types.d.ts" />
+       // deno-lint-ignore-file
+
+       ${finalCode}
+      `,
+    );
+
+    return tmp;
+  }
 
   function spawnWorker(perms: Permissions): void {
     new Worker(

--- a/src/cli/mod.ts
+++ b/src/cli/mod.ts
@@ -74,7 +74,7 @@ export function dzx() {
           const scriptExt = path.extname(script);
 
           $.mainModule = [".md", ".markdown"].includes(scriptExt)
-            ? await moduleFromMarkdown(script)
+            ? addProtocool(await moduleFromMarkdown(script))
             : addProtocool(script);
 
           if (worker) {

--- a/test.ts
+++ b/test.ts
@@ -76,6 +76,9 @@ Deno.test("markdown files can be executed as scripts", async () => {
   const output = await $
     `deno run -A --unstable ./dzx.ts ./examples/markdown.md`;
 
+  const outputLength = await $`echo ${output} | wc -l`;
+
+  assertEquals(Number(outputLength.stdout.trim()), 4);
   assertStringIncludes(output.stderr, `Markdown module saved to`);
   assertStringIncludes(output.stdout, `$ echo "Hello World!"`);
   assertStringIncludes(output.stdout, `$ echo "Hello again World!"`);

--- a/test.ts
+++ b/test.ts
@@ -76,9 +76,6 @@ Deno.test("markdown files can be executed as scripts", async () => {
   const output = await $
     `deno run -A --unstable ./dzx.ts ./examples/markdown.md`;
 
-  const outputLength = await $`echo ${output} | wc -l`;
-
-  assertEquals(Number(outputLength.stdout.trim()), 4);
   assertStringIncludes(output.stderr, `Markdown module saved to`);
   assertStringIncludes(output.stdout, `$ echo "Hello World!"`);
   assertStringIncludes(output.stdout, `$ echo "Hello again World!"`);

--- a/test.ts
+++ b/test.ts
@@ -3,6 +3,7 @@
 import {
   assert,
   assertEquals,
+  assertStringIncludes,
   assertThrowsAsync,
 } from "https://deno.land/std@0.104.0/testing/asserts.ts";
 
@@ -69,4 +70,13 @@ Deno.test("cwd of the parent process is always the starting point for calls to c
   } finally {
     Deno.chdir(parentPwd);
   }
+});
+
+Deno.test("markdown files can be executed as scripts", async () => {
+  const output = await $
+    `deno run -A --unstable ./dzx.ts ./examples/markdown.md`;
+
+  assertStringIncludes(output.stderr, `Markdown module saved to`);
+  assertStringIncludes(output.stdout, `$ echo "Hello World!"`);
+  assertStringIncludes(output.stdout, `$ echo "Hello again World!"`);
 });


### PR DESCRIPTION
The feature of https://github.com/google/zx to run markdown files as scripts is incredibly helpful
as it provides the ability to include nice looking and well structured documentation right alongside
your scripts. This was one of the largest outstanding features of zx which was absent from dzx, and
with this code in place, now dzx has the ability to run markdown files as scripts as well. See the
example markdown file for detailed documentation.