### PR TITLE
feat(env): add convenience apis for common scripting needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ notes.
   `` $`command` ``
 - **HOME:** Equivalent to `$HOME` (the users home directory) in the bash shell
 - **USER:** Equivalent to `$USER` (the current user) in the bash shell
+- **$1 through $9:** Equivalent to `$1`, `$2`, ... `$9` (the script arguments)
+  in the bash shell
 
 # CLI
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,57 @@ notes.
   }
   ```
 
+- `` $s`command` ``: Executes a shell command and _only returns its exit code_
+  (without throwing an error)
+
+  ```ts
+  const trueStatus = await $`true`);
+  console.log(trueStatus); // -> 0
+  ```
+
+  If the executed program returns a non-zero exit code, no error will be thrown.
+  Either the non-zero code will be the return value, or a `1` will be returned
+  by default.
+
+  ```ts
+  const falseStatus = await $`false`);
+  console.log(falseStatus); // -> 1
+  ```
+
+- `` $o`command` ``: Executes a shell command and _only returns its trimmed
+  stdout_ (without throwing an error)
+
+  ```ts
+  const stdout = await $`pwd`);
+  console.log(stdout); // -> '/home/code/project
+  ```
+
+  If the executed program returns a non-zero exit code, no error will be thrown.
+  Either the failed processes stdout will be the return value, or an empty
+  string will be returned by default
+
+  ```ts
+  const stdout = await $`echo 'hello' >&2; exit 1;`);
+  console.log(stdout); // -> ""
+  ```
+
+- `` $e`command` ``: Executes a shell command and _only returns its trimmed
+  stderr_ (without throwing an error)
+
+  ```ts
+  const stderr = await $`pwd`);
+  console.log(stderr); // -> ""
+  ```
+
+  If the executed program returns a non-zero exit code, no error will be thrown.
+  Either the failed processes stderr will be the return value, or an empty
+  string will be returned by default
+
+  ```ts
+  const stderr = await $`echo 'hello' >&2; exit 1;`);
+  console.log(stderr); // -> "hello"
+  ```
+
 - `cd()`: Change the current working directory. If path does not exist, an error
   is thrown. The path is always relative to the original `cwd`, unless the path
   is an absolute path or starts with `~` which indecates the home directory.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ await fs.ensureDir("./tmp");
 - [Usage](#usage)
   - [Permissions](#permissions)
   - [Worker](#worker)
+  - [Markdown](#markdown)
   - [Methods](#methods)
   - [Modules](#modules)
   - [Variables](#variables)
@@ -212,6 +213,24 @@ notes.
   console.log(Deno.cwd()); // --> [HOME]/Documents
   ```
 
+- `envExists()`: Checks if the specified environment variable is defined and
+  non-empty. Provided for convenience when you don't care about the value of a
+  variable, only that it is set.
+
+  ```ts
+  console.log(envExists("HOME")); // --> true
+  console.log(envExists("MADE_UP")); // --> false
+  ```
+
+- `envMissing()`: Checks if the specified environment variable is undefined or
+  empty. Provided for convenience when you don't care about the value of a
+  variable, only that it is absent.
+
+  ```ts
+  console.log(envMissing("HOME")); // --> false
+  console.log(envMissing("MADE_UP")); // --> true
+  ```
+
 - `` quote`string` ``: The quote methods quotes safly a string. by default the
   `shq` package is used. Can be overidden with `$.quote`.
 
@@ -283,6 +302,8 @@ notes.
 - **$.time:** The time left since execution start (now() - $.startTime).
 - **$.quote:** Parser method that is used to safely quote strings. Used by:
   `` $`command` ``
+- **HOME:** Equivalent to `$HOME` (the users home directory) in the bash shell
+- **USER:** Equivalent to `$USER` (the current user) in the bash shell
 
 # CLI
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -13,3 +13,31 @@ export function error(message: string | Error, exitCode = 1): Error {
 function getErrorMessage(message: string) {
   return $.red(`${$.bold("error:")} ${message}`);
 }
+
+export function homedir(throwIfMissing = true): string | undefined {
+  switch (Deno.build.os) {
+    case "windows":
+      return Deno.env.get("USERPROFILE");
+    case "linux":
+    case "darwin":
+      return Deno.env.get("HOME");
+    default:
+      if (throwIfMissing) {
+        throw error("Failed to retrieve home directory.");
+      }
+  }
+}
+
+export function username(throwIfMissing = true): string | undefined {
+  switch (Deno.build.os) {
+    case "windows":
+      return Deno.env.get("USERNAME");
+    case "linux":
+    case "darwin":
+      return Deno.env.get("USER");
+    default:
+      if (throwIfMissing) {
+        throw error("Failed to retrieve username.");
+      }
+  }
+}

--- a/src/runtime/cd.ts
+++ b/src/runtime/cd.ts
@@ -1,4 +1,4 @@
-import { error } from "../_utils.ts";
+import { error, homedir } from "../_utils.ts";
 import { path } from "./mod.ts";
 
 const cwd = Deno.cwd();
@@ -23,17 +23,5 @@ export function cd(dir: string) {
       throw error(`cd: ${dir}: Permission denied\n    at ${stack}`);
     }
     throw error(err);
-  }
-}
-
-function homedir(): string | null {
-  switch (Deno.build.os) {
-    case "windows":
-      return Deno.env.get("USERPROFILE") || null;
-    case "linux":
-    case "darwin":
-      return Deno.env.get("HOME") || null;
-    default:
-      throw error("Failed to retrive home directory.");
   }
 }

--- a/src/runtime/env.ts
+++ b/src/runtime/env.ts
@@ -1,9 +1,3 @@
-/** Equivalent to `$HOME` (the users home directory) in the bash shell */
-export const HOME = Deno.env.get("HOME");
-
-/** Equivalent to `$USER` (the current user) in the bash shell */
-export const USER = Deno.env.get("USER");
-
 /**
  * Check if the specified environment variable is set and is not empty.
  *

--- a/src/runtime/env.ts
+++ b/src/runtime/env.ts
@@ -1,0 +1,25 @@
+/** Equivalent to `$HOME` (the users home directory) in the bash shell */
+export const HOME = Deno.env.get("HOME");
+
+/** Equivalent to `$USER` (the current user) in the bash shell */
+export const USER = Deno.env.get("USER");
+
+/**
+ * Check if the specified environment variable is set and is not empty.
+ *
+ * @param envVarName the name of the environment variable
+ * @return true if the environment variable is set and not empty
+ */
+export function envExists(envVarName: string) {
+  return (Deno.env.get(envVarName) ?? "").trim() !== "";
+}
+
+/**
+ * Check if the specified environment variable is unset or is empty.
+ *
+ * @param envVarName the name of the environment variable
+ * @return true if the environment variable is unset or is empty
+ */
+export function envMissing(envVarName: string) {
+  return (Deno.env.get(envVarName) ?? "").trim() === "";
+}

--- a/src/runtime/exec.ts
+++ b/src/runtime/exec.ts
@@ -63,6 +63,66 @@ export async function exec(
   });
 }
 
+/**
+ * Run a command and return only its exit code
+ *
+ * If the command throws an error or fails in some way,
+ * this method will not re-throw that error. It will
+ * either return the exit code from the process, or `1`
+ * if no exit code is produced (due to an error)
+ *
+ * If you want assurance that a failure in the child process
+ * will throw an error, use `$`
+ * @see $
+ */
+export const statusOnly = async (
+  pieces: TemplateStringsArray,
+  ...args: Array<string | number | ProcessOutput>
+): Promise<number> =>
+  await exec(pieces, ...args)
+    .then((o) => (o instanceof ProcessOutput ? o.status.code : 0))
+    .catch((e) => (e instanceof ProcessError ? e.status.code : 1));
+
+/**
+ * Run a command and return only its trimmed stdout
+ *
+ * If the command throws an error or fails in some way,
+ * this method will not re-throw that error. It will only
+ * have output if the command produces text written
+ * to its stdout stream.
+ *
+ * If you want assurance that a failure in the child process
+ * will throw an error, use `$`
+ * @see $
+ */
+export const stdoutOnly = async (
+  pieces: TemplateStringsArray,
+  ...args: Array<string | number | ProcessOutput>
+): Promise<string> =>
+  await exec(pieces, ...args)
+    .then((o) => (o instanceof ProcessOutput ? o.stdout.trim() : ""))
+    .catch((e) => (e instanceof ProcessError ? e.stdout.trim() : ""));
+
+/**
+ * Run a command and return only its trimmed stderr
+ *
+ * If the command throws an error or fails in some way,
+ * this method will not re-throw that error. It will only
+ * have output if the command produces text written
+ * to its stderr stream.
+ *
+ * If you want assurance that a failure in the child process
+ * will throw an error, use `$`
+ * @see $
+ */
+export const stderrOnly = async (
+  pieces: TemplateStringsArray,
+  ...args: Array<string | number | ProcessOutput>
+): Promise<string> =>
+  await exec(pieces, ...args)
+    .then((o) => (o instanceof ProcessOutput ? o.stderr.trim() : ""))
+    .catch((e) => (e instanceof ProcessError ? e.stderr.trim() : ""));
+
 async function read(
   reader: Deno.Reader,
   ...results: Array<Array<string>>

--- a/src/runtime/mod.ts
+++ b/src/runtime/mod.ts
@@ -2,9 +2,10 @@
 
 import { async, colors, flags, fs, io, log, path, shq } from "./deps.ts";
 import { cd } from "./cd.ts";
-import { envExists, envMissing, HOME, USER } from "./env.ts";
+import { envExists, envMissing } from "./env.ts";
 import { exec } from "./exec.ts";
 import { quote } from "./quote.ts";
+import { homedir, username } from "../_utils.ts";
 
 export { ProcessError } from "./process_error.ts";
 export { ProcessOutput } from "./process_output.ts";
@@ -47,9 +48,6 @@ self.$ = $;
 self.cd = cd;
 self.quote = quote;
 
-self.HOME = HOME;
-self.USER = USER;
-
 // x
 self.async = async;
 self.path = path;
@@ -58,17 +56,15 @@ self.fs = fs;
 self.log = log;
 self.flags = flags;
 
-export {
-  async,
-  cd,
-  envExists,
-  envMissing,
-  flags,
-  fs,
-  HOME,
-  io,
-  log,
-  path,
-  quote,
-  USER,
-};
+// convenient env vars
+self.HOME = homedir(false);
+self.USER = username(false);
+
+// numeric script args ($0 is supplied by $.mainModule)
+[1, 2, 3, 4, 5, 6, 7, 8, 9].forEach((arg) => {
+  Object.defineProperty(self, `$${arg}`, {
+    get: () => $.args.at(arg - 1),
+  });
+});
+
+export { async, cd, envExists, envMissing, flags, fs, io, log, path, quote };

--- a/src/runtime/mod.ts
+++ b/src/runtime/mod.ts
@@ -3,7 +3,7 @@
 import { async, colors, flags, fs, io, log, path, shq } from "./deps.ts";
 import { cd } from "./cd.ts";
 import { envExists, envMissing } from "./env.ts";
-import { exec } from "./exec.ts";
+import { exec, statusOnly, stderrOnly, stdoutOnly } from "./exec.ts";
 import { quote } from "./quote.ts";
 import { homedir, username } from "../_utils.ts";
 
@@ -25,6 +25,9 @@ export type $ = typeof exec & typeof colors & {
 };
 
 export const $: $ = exec as $;
+export const $s: typeof statusOnly = statusOnly;
+export const $o: typeof stdoutOnly = stdoutOnly;
+export const $e: typeof stderrOnly = stderrOnly;
 
 Object.setPrototypeOf($, Object.getPrototypeOf(colors));
 
@@ -45,6 +48,9 @@ Object.defineProperty($, "time", {
 
 // dzx
 self.$ = $;
+self.$s = $s;
+self.$o = $o;
+self.$e = $e;
 self.cd = cd;
 self.quote = quote;
 

--- a/src/runtime/mod.ts
+++ b/src/runtime/mod.ts
@@ -2,6 +2,7 @@
 
 import { async, colors, flags, fs, io, log, path, shq } from "./deps.ts";
 import { cd } from "./cd.ts";
+import { envExists, envMissing, HOME, USER } from "./env.ts";
 import { exec } from "./exec.ts";
 import { quote } from "./quote.ts";
 
@@ -46,6 +47,9 @@ self.$ = $;
 self.cd = cd;
 self.quote = quote;
 
+self.HOME = HOME;
+self.USER = USER;
+
 // x
 self.async = async;
 self.path = path;
@@ -54,4 +58,17 @@ self.fs = fs;
 self.log = log;
 self.flags = flags;
 
-export { async, cd, flags, fs, io, log, path, quote };
+export {
+  async,
+  cd,
+  envExists,
+  envMissing,
+  flags,
+  fs,
+  HOME,
+  io,
+  log,
+  path,
+  quote,
+  USER,
+};

--- a/test.ts
+++ b/test.ts
@@ -7,12 +7,45 @@ import {
   assertThrowsAsync,
 } from "https://deno.land/std@0.104.0/testing/asserts.ts";
 
-import { $, cd, path, ProcessError } from "./mod.ts";
+import { $, $e, $o, $s, cd, path, ProcessError } from "./mod.ts";
 
 Deno.test("$ works", async () => {
   const result = await $`echo hello`;
 
   assertEquals(result.stdout, "hello\n");
+});
+
+Deno.test("$s works", async () => {
+  const result1 = await $s`echo hello`;
+  assertEquals(result1, 0);
+
+  const result2 = await $s`echo hello >&2`;
+  assertEquals(result2, 0);
+
+  const result3 = await $s`echo hello; exit 1;`;
+  assertEquals(result3, 1);
+});
+
+Deno.test("$o works", async () => {
+  const result1 = await $o`echo hello`;
+  assertEquals(result1, "hello");
+
+  const result2 = await $o`echo hello >&2`;
+  assertEquals(result2, "");
+
+  const result3 = await $o`echo hello; exit 1;`;
+  assertEquals(result3, "hello");
+});
+
+Deno.test("$e works", async () => {
+  const result1 = await $e`echo hello`;
+  assertEquals(result1, "");
+
+  const result2 = await $e`echo hello >&2`;
+  assertEquals(result2, "hello");
+
+  const result3 = await $e`echo hello; exit 1;`;
+  assertEquals(result3, "");
 });
 
 Deno.test("only stdout of an exec result will be used if passed to a second call to exec", async () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,8 @@
 import type {
   $,
+  $e as _$e,
+  $o as _$o,
+  $s as _$s,
   async as _async,
   cd as _cd,
   envExists as _envExists,
@@ -28,8 +31,53 @@ import type {
 type MaybeString = string | undefined;
 
 declare global {
-  // dzx
+  /**
+   * Run a command and return its output streams as well
+   * as details about the process exit status.
+   */
   const $: $;
+
+  /**
+   * Run a command and return only its exit code
+   *
+   * If the command throws an error or fails in some way,
+   * this method will not re-throw that error. It will
+   * either return the exit code from the process, or `1`
+   * if no exit code is produced (due to an error)
+   *
+   * If you want assurance that a failure in the child process
+   * will throw an error, use `$`
+   * @see $
+   */
+  const $s: typeof _$s;
+
+  /**
+   * Run a command and return only its trimmed stdout
+   *
+   * If the command throws an error or fails in some way,
+   * this method will not re-throw that error. It will only
+   * have output if the command produces text written
+   * to its stdout stream.
+   *
+   * If you want assurance that a failure in the child process
+   * will throw an error, use `$`
+   * @see $
+   */
+  const $o: typeof _$o;
+
+  /**
+   * Run a command and return only its trimmed stderr
+   *
+   * If the command throws an error or fails in some way,
+   * this method will not re-throw that error. It will only
+   * have output if the command produces text written
+   * to its stderr stream.
+   *
+   * If you want assurance that a failure in the child process
+   * will throw an error, use `$`
+   * @see exec
+   */
+  const $e: typeof _$e;
   const cd: typeof _cd;
   const quote: typeof _quote;
 
@@ -92,6 +140,9 @@ declare global {
   interface Window {
     // dzx
     $: $;
+    $s: typeof $s;
+    $o: typeof $o;
+    $e: typeof $e;
     cd: typeof _cd;
     quote: typeof _quote;
 
@@ -119,6 +170,9 @@ declare global {
   interface WorkerGlobalScope {
     // dzx
     $: $;
+    $s: typeof $s;
+    $o: typeof $o;
+    $e: typeof $e;
     cd: typeof _cd;
     quote: typeof _quote;
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -6,12 +6,10 @@ import type {
   envMissing as _envMissing,
   flags as _flags,
   fs as _fs,
-  HOME as _HOME,
   io as _io,
   log as _log,
   path as _path,
   quote as _quote,
-  USER as _USER,
 } from "./mod.ts";
 
 import type {
@@ -27,6 +25,8 @@ import type {
   ReadLineResult as _ReadLineResult,
 } from "./src/runtime/deps.ts";
 
+type MaybeString = string | undefined;
+
 declare global {
   // dzx
   const $: $;
@@ -34,9 +34,27 @@ declare global {
   const quote: typeof _quote;
 
   /** Equivalent to `$HOME` (the users home directory) in the bash shell */
-  const HOME: typeof _HOME;
+  const HOME: MaybeString;
   /** Equivalent to `$USER` (the current user) in the bash shell */
-  const USER: typeof _USER;
+  const USER: MaybeString;
+  /** The first argument to the script, equivalent to `$1` in the bash shell */
+  const $1: MaybeString;
+  /** The second argument to the script, equivalent to `$2` in the bash shell */
+  const $2: MaybeString;
+  /** The third argument to the script, equivalent to `$3` in the bash shell */
+  const $3: MaybeString;
+  /** The fourth argument to the script, equivalent to `$4` in the bash shell */
+  const $4: MaybeString;
+  /** The fifth argument to the script, equivalent to `$5` in the bash shell */
+  const $5: MaybeString;
+  /** The sixth argument to the script, equivalent to `$6` in the bash shell */
+  const $6: MaybeString;
+  /** The seventh argument to the script, equivalent to `$7` in the bash shell */
+  const $7: MaybeString;
+  /** The eighth argument to the script, equivalent to `$8` in the bash shell */
+  const $8: MaybeString;
+  /** The nineth argument to the script, equivalent to `$9` in the bash shell */
+  const $9: MaybeString;
 
   // x
   const async: typeof _async;
@@ -77,8 +95,17 @@ declare global {
     cd: typeof _cd;
     quote: typeof _quote;
 
-    HOME: typeof _HOME;
-    USER: typeof _USER;
+    HOME: MaybeString;
+    USER: MaybeString;
+    $1: MaybeString;
+    $2: MaybeString;
+    $3: MaybeString;
+    $4: MaybeString;
+    $5: MaybeString;
+    $6: MaybeString;
+    $7: MaybeString;
+    $8: MaybeString;
+    $9: MaybeString;
 
     // x
     async: typeof _async;
@@ -95,8 +122,17 @@ declare global {
     cd: typeof _cd;
     quote: typeof _quote;
 
-    HOME: typeof _HOME;
-    USER: typeof _USER;
+    HOME: MaybeString;
+    USER: MaybeString;
+    $1: MaybeString;
+    $2: MaybeString;
+    $3: MaybeString;
+    $4: MaybeString;
+    $5: MaybeString;
+    $6: MaybeString;
+    $7: MaybeString;
+    $8: MaybeString;
+    $9: MaybeString;
 
     // x
     async: typeof _async;

--- a/types.d.ts
+++ b/types.d.ts
@@ -2,12 +2,16 @@ import type {
   $,
   async as _async,
   cd as _cd,
+  envExists as _envExists,
+  envMissing as _envMissing,
   flags as _flags,
   fs as _fs,
+  HOME as _HOME,
   io as _io,
   log as _log,
   path as _path,
   quote as _quote,
+  USER as _USER,
 } from "./mod.ts";
 
 import type {
@@ -28,6 +32,11 @@ declare global {
   const $: $;
   const cd: typeof _cd;
   const quote: typeof _quote;
+
+  /** Equivalent to `$HOME` (the users home directory) in the bash shell */
+  const HOME: typeof _HOME;
+  /** Equivalent to `$USER` (the current user) in the bash shell */
+  const USER: typeof _USER;
 
   // x
   const async: typeof _async;
@@ -68,6 +77,9 @@ declare global {
     cd: typeof _cd;
     quote: typeof _quote;
 
+    HOME: typeof _HOME;
+    USER: typeof _USER;
+
     // x
     async: typeof _async;
     path: typeof _path;
@@ -82,6 +94,9 @@ declare global {
     $: $;
     cd: typeof _cd;
     quote: typeof _quote;
+
+    HOME: typeof _HOME;
+    USER: typeof _USER;
 
     // x
     async: typeof _async;


### PR DESCRIPTION
Borrowing from my own project which I _started_ prior to learning about yours (https://github.com/andrewbrey/desh), I have found that there are a few things I end up repeating in every almost single script, so it's really convenient to have them just be baked into the runtime api. This PR adds some of these:

- Globally available variables for the `HOME` and `USER` environment vars since they are so commonly accessed
- Globally available variables which are the equivalent of the numerically indexed script arguments, i.e. `$1`, `$2`, etc. We already have `$.args` but it's very convenient to be able to access common values in that array without hassle
- Most importantly, convenience wrappers around `$` for extracting only the exit code, the trimmed stdout, or the trimmed stderr. In this PR, these are provided as:
	- the `$s` template tag which extracts only the exit status of a command
	- the `$o` template tag which extracts only the trimmed child process stdout
	- the `$e` template tag which extracts only the trimmed child process stderr

Let me know if you have questions or want changes! Hopefully you like these kinds of convenience additions to the runtime API :)