### PR TITLE
feat(runtime): capture stack trace from `$` call's

### DIFF
--- a/src/runtime/exec.ts
+++ b/src/runtime/exec.ts
@@ -23,7 +23,9 @@ export function exec(
     console.log($.brightBlue("$ %s"), cmd);
   }
 
-  return new Process(cmd);
+  return new Process(cmd, {
+    errorContext: exec,
+  });
 }
 
 /**

--- a/src/runtime/process_error.ts
+++ b/src/runtime/process_error.ts
@@ -11,14 +11,16 @@ export class ProcessError extends Error {
   #combined!: string;
   #status!: Deno.ProcessStatus;
 
+  static merge(target: ProcessError, source: ProcessError): ProcessError {
+    target.#name = source.name;
+    target.#merge(source);
+    return target;
+  }
+
   constructor(options: ProcessErrorOptions) {
     super();
     Object.setPrototypeOf(this, ProcessError.prototype);
-    this.#stdout = options.stdout;
-    this.#stderr = options.stderr;
-    this.#combined = options.combined;
-    this.#status = options.status;
-    this.message = this.#getErrorMessage();
+    this.#merge(options);
   }
 
   get name(): string {
@@ -39,6 +41,16 @@ export class ProcessError extends Error {
 
   get status(): Deno.ProcessStatus {
     return this.#status;
+  }
+
+  #merge(
+    { stdout, stderr, combined, status }: ProcessErrorOptions,
+  ): void {
+    this.#stdout = stdout;
+    this.#stderr = stderr;
+    this.#combined = combined;
+    this.#status = status;
+    this.message = this.#getErrorMessage();
   }
 
   #getErrorMessage(): string {


### PR DESCRIPTION
Re-implementation from #40 

Print correct stack trace:

```console
$ exit 1
error: Uncaught (in promise) ProcessError: Command failed.
Exit code: 1
await $`exit 1`;
       ^
    at file:///examples.ts:7:8
```